### PR TITLE
Added a dockerfile for the build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && \ 
+    apt-get install -y software-properties-common && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN apt-add-repository universe && \
+    apt-get update && \
+    apt-get install -y python2-minimal git curl wget && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py && \
+    python2 get-pip.py && \
+    rm get-pip.py
+
+RUN python2 -m pip install virtualenv
+
+WORKDIR /app
+
+COPY ./requirements.txt /app
+
+RUN mkdir /home/python && \
+    python2 -m virtualenv /home/python/venv 
+
+RUN /bin/bash -c "source /home/python/venv/bin/activate && pip install -r /app/requirements.txt"
+
+ENTRYPOINT [ "/app/docker_entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,12 @@ python2 -m virtualenv venv
 source venv/bin/activate
 pip install -r requirements.txt
 ```
-
+Or using docker for the build enviroment (works on any distribution):
+```bash
+git clone --recurse-submodules https://github.com/kendallgoto/ilo4_unlock.git
+cd ilo4_unlock
+docker build -t ilo4_unlock .
+```
 ## Building Firmware
 ``` bash
 ./build.sh init # download necessary HPE binaries
@@ -36,6 +41,14 @@ pip install -r requirements.txt
 ./build.sh 277  # generate iLO v2.77 patched firmware
 # The build setup creates a build/ folder where all the artifacts are stored. The final firmware location will be printed at the end of the script, if no errors are produced.
 ```
+Or if you are using the docker container. Make sure you are in the `ilo4_unlock` directory first.
+```bash
+docker run --rm -it -v $(pwd):/app ilo4_unlock:latest init # download necessary HPE binaries
+#docker run --rm -it -v $(pwd):/app ilo4_unlock:latest [patch-name] -- see patches/ folder for more info on each patch!
+docker run --rm -it -v $(pwd):/app ilo4_unlock:latest 277  # generate iLO v2.77 patched firmware
+# The build setup creates a build/ folder where all the artifacts are stored. The final firmware location will be printed at the end of the script, if no errors are produced.
+```
+
 ## Flashing Firmware
 The resulting firmware is located in the `build` directory, under the firmware's name (e.g. `build/ilo4_273.bin.patched` for v2.73 builds). I suggest the following steps to flash the firmware, as you cannot do it from the web interface:
 1. Copy the resulting firmware to a USB key, along with the flasher files (`binaries/flash_ilo4` & `binaries/CP027911.xml`)

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# This file is part of ilo4_unlock (https://github.com/kendallgoto/ilo4_unlock/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+source /home/python/venv/bin/activate
+/app/build.sh $1


### PR DESCRIPTION
This Pr adds a dockerfile to encapsulate the python2 build dependencies of the build script. This allows the script to be run on any platforms that has docker installed and prevents installing python2 directly on your computer. 

To use the container to patch the firmware, you only need to build the container and then run it as showed in the readme.

Let me know what you think of it! 



